### PR TITLE
use module.ModularMain

### DIFF
--- a/cmd/module/main.go
+++ b/cmd/module/main.go
@@ -13,6 +13,6 @@ import (
 )
 
 func main() {
-	module.ModularMain(resource.APIModel{vision.API, countclassifier.Model},
-	                   resource.APIModel{sensor.API, countsensor.Model})
+	module.ModularMain(resource.APIModel{API: vision.API, Model: countclassifier.Model},
+	                   resource.APIModel{API: sensor.API, Model: countsensor.Model})
 }

--- a/cmd/module/main.go
+++ b/cmd/module/main.go
@@ -2,43 +2,17 @@
 package main
 
 import (
-	"context"
-
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/services/vision"
 
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
-	"go.viam.com/utils"
+	"go.viam.com/rdk/resource"
 
 	"github.com/viam-modules/vision-summary/countclassifier"
 	"github.com/viam-modules/vision-summary/countsensor"
 )
 
 func main() {
-	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("vision-summary"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
-	myMod, err := module.NewModuleFromArgs(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.AddModelFromRegistry(ctx, vision.API, countclassifier.Model)
-	if err != nil {
-		return err
-	}
-	err = myMod.AddModelFromRegistry(ctx, sensor.API, countsensor.Model)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.Start(ctx)
-	defer myMod.Close(ctx)
-	if err != nil {
-		return err
-	}
-	<-ctx.Done()
-	return nil
+	module.ModularMain(resource.APIModel{vision.API, countclassifier.Model},
+	                   resource.APIModel{sensor.API, countsensor.Model})
 }


### PR DESCRIPTION
This is such a common pattern that has been copied so many times, that we've just made a helper function for it. 

Everything compiles (`make module.tar.gz` succeeds), though I haven't tried it further than that.